### PR TITLE
Ordenar eventos

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "generate:types": "cross-env PAYLOAD_CONFIG_PATH=src/payload.config.ts payload generate:types",
     "generate:graphQLSchema": "cross-env PAYLOAD_CONFIG_PATH=src/payload.config.ts payload generate:graphQLSchema",
     "payload": "cross-env PAYLOAD_CONFIG_PATH=src/payload.config.ts payload",
-    "lint": "eslint ."
+    "lint": "eslint --fix ."
   },
   "dependencies": {
     "@payloadcms/bundler-webpack": "^1.0.0",

--- a/src/collections/Eventos/hooks/insertFechas.ts
+++ b/src/collections/Eventos/hooks/insertFechas.ts
@@ -1,0 +1,29 @@
+import { CollectionBeforeChangeHook } from "payload/types";
+
+export const insertFechas: CollectionBeforeChangeHook = async ({
+  data, // incoming data to update or create with
+  req, // full express request
+  operation, // name of the operation ie. 'create', 'update'
+  originalDoc, // original document
+}) => {
+  // If the incoming data has the `enable_multi_dates` checkbox checked
+  if (data.enable_multi_dates) {
+    // If the incoming data has the `fecha_unica` field
+    // order date.fechas_horas by date.fecha_hora
+    data.fechas_horas.sort((a, b) => {
+      return (
+        new Date(a.fecha_hora).getTime() - new Date(b.fecha_hora).getTime()
+      );
+    });
+    data.fecha_inicio = new Date(data.fechas_horas[0].fecha_hora);
+    data.fecha_fin = new Date(
+      data.fechas_horas[data.fechas_horas.length - 1].fecha_hora,
+    );
+  } else {
+    const fecha_unica = new Date(data.fecha_unica);
+    data.fecha_inicio = fecha_unica;
+    data.fecha_fin = fecha_unica;
+    data.fechas_horas = [{ fecha_hora: fecha_unica }];
+  }
+  return data; // Return data to either create or update a document with
+};

--- a/src/collections/Eventos/hooks/insertFechas.ts
+++ b/src/collections/Eventos/hooks/insertFechas.ts
@@ -2,9 +2,9 @@ import { CollectionBeforeChangeHook } from "payload/types";
 
 export const insertFechas: CollectionBeforeChangeHook = async ({
   data, // incoming data to update or create with
-  req, // full express request
-  operation, // name of the operation ie. 'create', 'update'
-  originalDoc, // original document
+  req: _req, // full express request
+  operation: _operation, // name of the operation ie. 'create', 'update'
+  originalDoc: _originalDoc, // original document
 }) => {
   // If the incoming data has the `enable_multi_dates` checkbox checked
   if (data.enable_multi_dates) {

--- a/src/collections/Eventos/index.ts
+++ b/src/collections/Eventos/index.ts
@@ -11,7 +11,7 @@ export const Eventos: CollectionConfig = {
   },
   admin: {
     useAsTitle: "titulo",
-    defaultColumns: ["tipo", "titulo", "fecha", "lugar", "cupos"],
+    defaultColumns: ["tipo", "titulo", "fecha_inicio", "lugar", "cupos"],
   },
   hooks: {
     beforeChange: [insertFechas],

--- a/src/collections/Eventos/index.ts
+++ b/src/collections/Eventos/index.ts
@@ -1,4 +1,7 @@
 import { CollectionConfig } from "payload/types";
+import { insertFechas } from "./hooks/insertFechas";
+
+const fecha_minima = new Date(2014, 0, 1);
 
 export const Eventos: CollectionConfig = {
   slug: "eventos",
@@ -9,6 +12,9 @@ export const Eventos: CollectionConfig = {
   admin: {
     useAsTitle: "titulo",
     defaultColumns: ["tipo", "titulo", "fecha", "lugar", "cupos"],
+  },
+  hooks: {
+    beforeChange: [insertFechas],
   },
   access: {
     create: () => true,
@@ -30,27 +36,42 @@ export const Eventos: CollectionConfig = {
       required: true,
     },
     {
-      name: "fecha_inicio",
-      label: "Fecha de inicio",
+      name: "enable_multi_dates",
+      type: "checkbox", // required
+      label: "Presioname para habilitar multiples fechas y horas",
+      defaultValue: false,
+    },
+    {
+      name: "fecha_unica",
+      label: "Fecha del evento",
       type: "date",
+      required: true,
       admin: {
+        condition: (data) => {
+          return !data.enable_multi_dates;
+        },
+        description: "Fecha en que sucede el evento.",
         date: {
+          minDate: fecha_minima,
           pickerAppearance: "dayAndTime",
-
           timeFormat: "HH:mm",
         },
       },
     },
+
     {
-      name: "fecha_fin",
-      label: "Fecha fin",
+      name: "fecha_inicio",
+      label: "Fecha de inicio",
       type: "date",
+      required: true,
+
       admin: {
+        disabled: true,
         description:
-          "Ultima fecha de un evento que dura varios días. Deberá de ser la misma que la ultima fecha de la lista de fechas y horas.",
+          "Fecha en que inicia el evento. Deberá de ser la misma que la primera fecha de la lista de fechas y horas.",
         date: {
           pickerAppearance: "dayAndTime",
-
+          minDate: fecha_minima,
           timeFormat: "HH:mm",
         },
       },
@@ -64,6 +85,13 @@ export const Eventos: CollectionConfig = {
         singular: "Fecha y Hora",
         plural: "Fechas y Horas",
       },
+      admin: {
+        condition: (data) => {
+          return data.enable_multi_dates;
+        },
+        description:
+          "Lista de fechas y horas en las que se llevará a cabo el evento. Instroducir una unica fecha si el evento no durá más de un día.",
+      },
       fields: [
         {
           name: "fecha_hora",
@@ -72,12 +100,28 @@ export const Eventos: CollectionConfig = {
           admin: {
             date: {
               pickerAppearance: "dayAndTime",
-
+              minDate: fecha_minima,
               timeFormat: "HH:mm",
             },
           },
         },
       ],
+    },
+    {
+      name: "fecha_fin",
+      label: "Fecha fin",
+      required: true,
+      type: "date",
+      admin: {
+        disabled: true,
+        description:
+          "Ultima fecha de un evento que dura varios días. Deberá de ser la misma que la ultima fecha de la lista de fechas y horas. Si el evento dura un solo día, deberá de ser la misma que la fecha de inicio.",
+        date: {
+          pickerAppearance: "dayAndTime",
+          minDate: fecha_minima,
+          timeFormat: "HH:mm",
+        },
+      },
     },
     {
       name: "lugar",

--- a/src/collections/Eventos/index.ts
+++ b/src/collections/Eventos/index.ts
@@ -30,6 +30,32 @@ export const Eventos: CollectionConfig = {
       required: true,
     },
     {
+      name: "fecha_inicio",
+      label: "Fecha de inicio",
+      type: "date",
+      admin: {
+        date: {
+          pickerAppearance: "dayAndTime",
+
+          timeFormat: "HH:mm",
+        },
+      },
+    },
+    {
+      name: "fecha_fin",
+      label: "Fecha fin",
+      type: "date",
+      admin: {
+        description:
+          "Ultima fecha de un evento que dura varios días. Deberá de ser la misma que la ultima fecha de la lista de fechas y horas.",
+        date: {
+          pickerAppearance: "dayAndTime",
+
+          timeFormat: "HH:mm",
+        },
+      },
+    },
+    {
       name: "fechas_horas",
       label: "Fechas y Horas",
       type: "array",

--- a/src/collections/Eventos/index.ts
+++ b/src/collections/Eventos/index.ts
@@ -22,6 +22,7 @@ export const Eventos: CollectionConfig = {
     delete: () => true,
     update: () => true,
   },
+  defaultSort: "-fecha_fin",
   fields: [
     //En el futuro puede ser una relación con la colección de categorias/tipo de evento
     {


### PR DESCRIPTION
## Describe your changes

Se agregó un checkbox para escoger si el evento es de un solo día o de múltiples días.  En caso de que sea de un día, muestra solo un campo, en caso de que sea de múltiples días despliega un campo de un arreglo de fechas. También se agregaron los campos de fecha fin y fecha inicio para cuestiones de ordenamiento. Estos campos no se mostrarán al administrador. Se agregó un hook para controlar las fechas de los eventos de tal modo que si es una fecha única se introduzca en el arreglo de fechas, en fecha fin y fecha inicio. En caso de que sea múltiples fechas, ordena las fechas por orden ascendente, introduce la primera fecha en fecha inicio e introduce la ultima fecha en fecha fin.

## Task URL Notion

[Ordenamiento de colecciones](https://www.notion.so/Ordenamiento-de-colecciones-7840eefecc7e48f2976df4f59b958a8c?pvs=4)

## What was done in this pull request

- [x] Agregar campo fecha fin
- [x] Agregar campo fecha inicio
- [x] Agregar hook para control de fechas

## Demo / Screenshot / Video

![image](https://github.com/CSIPro/csipro-cms/assets/91043170/5e0fc48a-fc95-4502-95fe-77a7995bc535)

![image](https://github.com/CSIPro/csipro-cms/assets/91043170/c7f3cc66-6c7b-4763-b411-2a26b4856642)

